### PR TITLE
Include cassert in sha3

### DIFF
--- a/src/crypto/sha3.cpp
+++ b/src/crypto/sha3.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <array>
 #include <bit>
+#include <cassert>
 #include <cstdint>
 #include <span>
 


### PR DESCRIPTION
## Summary
- add `<cassert>` to `src/crypto/sha3.cpp`
- verify cmake configuration step fails due to missing Boost

## Testing
- `cmake -B build` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_685545c1b83083219838155f36a5dfd0