### PR TITLE
Add SHA3_512 coverage to crypto fuzzer

### DIFF
--- a/src/crypto/sha3.cpp
+++ b/src/crypto/sha3.cpp
@@ -153,3 +153,55 @@ SHA3_256& SHA3_256::Reset()
     std::fill(std::begin(m_state), std::end(m_state), 0);
     return *this;
 }
+
+SHA3_512& SHA3_512::Write(std::span<const unsigned char> data)
+{
+    if (m_bufsize && data.size() >= sizeof(m_buffer) - m_bufsize) {
+        // Fill the buffer and process it.
+        std::copy(data.begin(), data.begin() + (sizeof(m_buffer) - m_bufsize), m_buffer + m_bufsize);
+        data = data.subspan(sizeof(m_buffer) - m_bufsize);
+        m_state[m_pos++] ^= ReadLE64(m_buffer);
+        m_bufsize = 0;
+        if (m_pos == RATE_BUFFERS) {
+            KeccakF(m_state);
+            m_pos = 0;
+        }
+    }
+    while (data.size() >= sizeof(m_buffer)) {
+        // Process chunks directly from the buffer.
+        m_state[m_pos++] ^= ReadLE64(data.data());
+        data = data.subspan(8);
+        if (m_pos == RATE_BUFFERS) {
+            KeccakF(m_state);
+            m_pos = 0;
+        }
+    }
+    if (data.size()) {
+        // Keep the remainder in the buffer.
+        std::copy(data.begin(), data.end(), m_buffer + m_bufsize);
+        m_bufsize += data.size();
+    }
+    return *this;
+}
+
+SHA3_512& SHA3_512::Finalize(std::span<unsigned char> output)
+{
+    assert(output.size() == OUTPUT_SIZE);
+    std::fill(m_buffer + m_bufsize, m_buffer + sizeof(m_buffer), 0);
+    m_buffer[m_bufsize] ^= 0x06;
+    m_state[m_pos] ^= ReadLE64(m_buffer);
+    m_state[RATE_BUFFERS - 1] ^= 0x8000000000000000;
+    KeccakF(m_state);
+    for (unsigned i = 0; i < 8; ++i) {
+        WriteLE64(output.data() + 8 * i, m_state[i]);
+    }
+    return *this;
+}
+
+SHA3_512& SHA3_512::Reset()
+{
+    m_bufsize = 0;
+    m_pos = 0;
+    std::fill(std::begin(m_state), std::end(m_state), 0);
+    return *this;
+}

--- a/src/crypto/sha3.h
+++ b/src/crypto/sha3.h
@@ -38,4 +38,29 @@ public:
     SHA3_256& Reset();
 };
 
+class SHA3_512
+{
+private:
+    uint64_t m_state[25] = {0};
+    unsigned char m_buffer[8];
+    unsigned m_bufsize = 0;
+    unsigned m_pos = 0;
+
+    //! Sponge rate in bits.
+    static constexpr unsigned RATE_BITS = 576;
+
+    //! Sponge rate expressed as a multiple of the buffer size.
+    static constexpr unsigned RATE_BUFFERS = RATE_BITS / (8 * sizeof(m_buffer));
+
+    static_assert(RATE_BITS % (8 * sizeof(m_buffer)) == 0, "Rate must be a multiple of 8 bytes");
+
+public:
+    static constexpr size_t OUTPUT_SIZE = 64;
+
+    SHA3_512() = default;
+    SHA3_512& Write(std::span<const unsigned char> data);
+    SHA3_512& Finalize(std::span<unsigned char> output);
+    SHA3_512& Reset();
+};
+
 #endif // BITCOIN_CRYPTO_SHA3_H

--- a/src/test/fuzz/crypto.cpp
+++ b/src/test/fuzz/crypto.cpp
@@ -36,6 +36,7 @@ FUZZ_TARGET(crypto)
     CSHA256 sha256;
     CSHA512 sha512;
     SHA3_256 sha3;
+    SHA3_512 sha3_512;
     CSipHasher sip_hasher{fuzzed_data_provider.ConsumeIntegral<uint64_t>(), fuzzed_data_provider.ConsumeIntegral<uint64_t>()};
 
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 30)
@@ -60,6 +61,7 @@ FUZZ_TARGET(crypto)
                 (void)sha1.Write(data.data(), data.size());
                 (void)sha256.Write(data.data(), data.size());
                 (void)sha3.Write(data);
+                (void)sha3_512.Write(data);
                 (void)sha512.Write(data.data(), data.size());
                 (void)sip_hasher.Write(data);
 
@@ -74,6 +76,7 @@ FUZZ_TARGET(crypto)
                 (void)sha1.Reset();
                 (void)sha256.Reset();
                 (void)sha3.Reset();
+                (void)sha3_512.Reset();
                 (void)sha512.Reset();
             },
             [&] {
@@ -118,6 +121,10 @@ FUZZ_TARGET(crypto)
                     [&] {
                         data.resize(SHA3_256::OUTPUT_SIZE);
                         sha3.Finalize(data);
+                    },
+                    [&] {
+                        data.resize(SHA3_512::OUTPUT_SIZE);
+                        sha3_512.Finalize(data);
                     });
             });
     }


### PR DESCRIPTION
## Summary
- extend SHA3 implementation with SHA3_512 class
- exercise SHA3_512 in the `crypto` fuzzer

## Testing
- `cmake -B build` *(fails: Could NOT find Boost)*
- `make -C build fuzz-crypto` *(fails: No rule to make target `fuzz-crypto`)*

------
https://chatgpt.com/codex/tasks/task_e_685545c34ce083218fd1da82d67968b2