### PR TITLE
Fix translation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ not straightforward.
 Translations
 ------------
 
-Changes to translations as well as new translations can be submitted to
-[Bitcoin Core's Transifex page](https://explore.transifex.com/bitcoin/bitcoin/).
+Changes to translations and new translations are inherited from Bitcoin Core.
+Submit them on [Bitcoin Core's Transifex page](https://explore.transifex.com/bitcoin/bitcoin/).
 
 Translations are periodically pulled from Transifex and merged into the git repository. See the
 [translation process](doc/translation_process.md) for details on how this works.


### PR DESCRIPTION
## Summary
- clarify that Baxium inherits translations from Bitcoin Core
- keep link to Bitcoin Core's Transifex page

## Testing
- `cmake -B build` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_685545c517e8832198089a07cae2d3c0