### PR TITLE
Add SHA3 block header test

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(test_bitcoin
   blockencodings_tests.cpp
   blockfilter_index_tests.cpp
   blockfilter_tests.cpp
+  blockhash_sha3_tests.cpp
   blockmanager_tests.cpp
   bloom_tests.cpp
   bswap_tests.cpp

--- a/src/test/blockhash_sha3_tests.cpp
+++ b/src/test/blockhash_sha3_tests.cpp
@@ -1,0 +1,15 @@
+#include <boost/test/unit_test.hpp>
+#include <test/util/setup_common.h>
+#include <primitives/block.h>
+#include <uint256.h>
+
+BOOST_FIXTURE_TEST_SUITE(blockhash_sha3_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(default_header_hash)
+{
+    CBlockHeader header;
+    const uint256 expected{"c449874bf12798a85265e027fdae6d670e65a2e74cdd625718a00d52dae3813f"};
+    BOOST_CHECK_EQUAL(header.GetHash(), expected);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- add `blockhash_sha3_tests.cpp`
- ensure new test is compiled by updating `src/test/CMakeLists.txt`

## Testing
- `cmake -B build && make -C build check` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_685545c797948321b23206185d96f7d3