### PR TITLE
Fix hash header guards

### DIFF
--- a/src/crypto/muhash.h
+++ b/src/crypto/muhash.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_MUHASH_H
-#define BITCOIN_CRYPTO_MUHASH_H
+#ifndef BAXIUM_CRYPTO_MUHASH_H
+#define BAXIUM_CRYPTO_MUHASH_H
 
 #include <serialize.h>
 #include <uint256.h>
@@ -133,4 +133,4 @@ public:
     }
 };
 
-#endif // BITCOIN_CRYPTO_MUHASH_H
+#endif // BAXIUM_CRYPTO_MUHASH_H

--- a/src/crypto/siphash.h
+++ b/src/crypto/siphash.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CRYPTO_SIPHASH_H
-#define BITCOIN_CRYPTO_SIPHASH_H
+#ifndef BAXIUM_CRYPTO_SIPHASH_H
+#define BAXIUM_CRYPTO_SIPHASH_H
 
 #include <cstdint>
 
@@ -45,4 +45,4 @@ public:
 uint64_t SipHashUint256(uint64_t k0, uint64_t k1, const uint256& val);
 uint64_t SipHashUint256Extra(uint64_t k0, uint64_t k1, const uint256& val, uint32_t extra);
 
-#endif // BITCOIN_CRYPTO_SIPHASH_H
+#endif // BAXIUM_CRYPTO_SIPHASH_H

--- a/src/hash.h
+++ b/src/hash.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_HASH_H
-#define BITCOIN_HASH_H
+#ifndef BAXIUM_HASH_H
+#define BAXIUM_HASH_H
 
 #include <attributes.h>
 #include <crypto/common.h>
@@ -226,4 +226,4 @@ inline uint160 RIPEMD160(std::span<const unsigned char> data)
     return result;
 }
 
-#endif // BITCOIN_HASH_H
+#endif // BAXIUM_HASH_H

--- a/src/util/bytevectorhash.h
+++ b/src/util/bytevectorhash.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UTIL_BYTEVECTORHASH_H
-#define BITCOIN_UTIL_BYTEVECTORHASH_H
+#ifndef BAXIUM_UTIL_BYTEVECTORHASH_H
+#define BAXIUM_UTIL_BYTEVECTORHASH_H
 
 #include <cstdint>
 #include <cstddef>
@@ -24,4 +24,4 @@ public:
     size_t operator()(const std::vector<unsigned char>& input) const;
 };
 
-#endif // BITCOIN_UTIL_BYTEVECTORHASH_H
+#endif // BAXIUM_UTIL_BYTEVECTORHASH_H

--- a/src/util/hash_type.h
+++ b/src/util/hash_type.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UTIL_HASH_TYPE_H
-#define BITCOIN_UTIL_HASH_TYPE_H
+#ifndef BAXIUM_UTIL_HASH_TYPE_H
+#define BAXIUM_UTIL_HASH_TYPE_H
 
 template <typename HashType>
 class BaseHash
@@ -69,4 +69,4 @@ public:
     const unsigned char* data() const { return m_hash.data(); }
 };
 
-#endif // BITCOIN_UTIL_HASH_TYPE_H
+#endif // BAXIUM_UTIL_HASH_TYPE_H

--- a/src/util/hasher.h
+++ b/src/util/hasher.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UTIL_HASHER_H
-#define BITCOIN_UTIL_HASHER_H
+#ifndef BAXIUM_UTIL_HASHER_H
+#define BAXIUM_UTIL_HASHER_H
 
 #include <crypto/common.h>
 #include <crypto/siphash.h>
@@ -97,4 +97,4 @@ public:
     size_t operator()(const std::span<const unsigned char>& script) const;
 };
 
-#endif // BITCOIN_UTIL_HASHER_H
+#endif // BAXIUM_UTIL_HASHER_H


### PR DESCRIPTION
## Summary
- switch several headers to use BAXIUM prefixed include guards

## Testing
- `cmake -B build` *(fails: Could NOT find Boost)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68556706f5d083218862c2853e972a6f